### PR TITLE
Sets the base URL for the relative data.redirect URL

### DIFF
--- a/assets/js/ledyer-checkout-for-woocommerce.js
+++ b/assets/js/ledyer-checkout-for-woocommerce.js
@@ -542,7 +542,7 @@ jQuery( function ( $ ) {
 									lco_wc.logToFile(
 										'Successfully created order in WooCommerce.'
 									);
-									const url = new URL( data.redirect );
+									const url = new URL( data.redirect, location.origin );
 									sessionStorage.setItem(
 										'ledyerWooRedirectUrl',
 										url


### PR DESCRIPTION
Since the data.redirect  URL is relative, it requires a base. For this reason, we have to include the location.origin. 

The missing base has resulted in the `new URL` failing (since it is undefined), triggering the catch clause which results in the customer remaining on the checkout page while Ledyer iframe shows the confirmation message.