### PR TITLE
Process order on redirect, confirm through callback

### DIFF
--- a/classes/admin/class-ledyer-meta-box.php
+++ b/classes/admin/class-ledyer-meta-box.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * Meta box
  *
@@ -29,7 +29,7 @@ class Meta_Box {
 	/**
 	 * Adds meta box to the side of a LCO order.
 	 *
-	 * @param string $screen_id The WordPress admin screen ID.
+	 * @param string $post_type The WordPress admin screen ID.
 	 * @return void
 	 */
 	public function add_meta_boxes( $post_type ) {
@@ -168,7 +168,9 @@ class Meta_Box {
 					<?php echo esc_html( implode( ', ', $ledyer_order['riskProfile']['tags'] ) ); ?><br />
 				<?php endif; ?>
 				<strong><?php esc_html_e( 'Updated: ', 'ledyer-checkout-for-woocommerce' ); ?> </strong>
-				<?php echo esc_html( sprintf( __( '%1$s at %2$s', 'woocommerce' ), date_i18n( wc_date_format(), strtotime( $ledyer_order['updatedAt'] ) ), date_i18n( wc_time_format(), strtotime( $ledyer_order['updatedAt'] ) ) ) ); ?><br />
+				<?php // @TODO - See if this needs to change. ?>
+				<?php // translators: %1$s: date, %2$s: date. ?>
+				<?php echo esc_html( sprintf( __( '%1$s at %2$s', 'ledyer-checkout-for-woocommerce' ), date_i18n( wc_date_format(), strtotime( $ledyer_order['updatedAt'] ) ), date_i18n( wc_time_format(), strtotime( $ledyer_order['updatedAt'] ) ) ) ); ?><br />
 			<?php } ?>
 		</div>
 		<?php

--- a/classes/class-ledyer-callback.php
+++ b/classes/class-ledyer-callback.php
@@ -266,18 +266,18 @@ class Callback {
 
 
 	    			$order->add_order_note( $note );
+					$ack_order = true;
 
-	    			// If the order does not need payment, we need to ensure the "ready-for-capture" event has been triggered.
+					// If the order does not need payment, we need to ensure the "ready-for-capture" event has been triggered.
 	    			$ready_for_capture = $order->get_meta( '_ledyer_ready_for_capture', true );
 	    			if ( ! $order->needs_payment() && empty( $ready_for_capture ) ) {
 	    				// Set the metadata to indicate the order is still waiting for the ready for capture event.
 	    				$order->update_meta_data( '_ledyer_waiting_on_ready_for_capture', true );
 	    				$order->save();
 	    				Logger::log( "[SCHEDULER]: Order {$order->get_order_number()} is paid but waiting for ready_for_capture event." );
-	    				return;
+	    				break;
 	    			}
 	    			$order->payment_complete( $ledyer_order_id );
-	    			$ack_order = true;
 	    		}
 	    		break;
 	    	case \LedyerPaymentStatus::ORDER_CAPTURED:

--- a/classes/class-ledyer-callback.php
+++ b/classes/class-ledyer-callback.php
@@ -144,15 +144,15 @@ class Callback {
 
 		Logger::log( "[SCHEDULER]: Order to process: $order_id" );
 
-		if ( 'com.ledyer.order.ready_for_capture' === $ledyer_event_type ) {
-			$order->update_meta_data( '_ledyer_ready_for_capture', true );
-			$order->save();
-			return;
-		}
-
 		$ledyer_payment_status = ledyer()->api->get_payment_status( $ledyer_order_id );
 		if ( is_wp_error( $ledyer_payment_status ) ) {
 			Logger::log( "[SCHEDULER]: Could not get ledyer payment status $ledyer_order_id" );
+			return;
+		}
+
+		// Process the ready for capture event.
+		if ( 'com.ledyer.order.ready_for_capture' === $ledyer_event_type ) {
+			$this->process_ready_for_capture( $ledyer_payment_status, $order, $ledyer_order_id );
 			return;
 		}
 
@@ -186,89 +186,144 @@ class Callback {
 			$order->save();
 		}
 
+		$this->process_order_status( $ledyer_payment_status, $order, $ledyer_order_id );
+	}
+
+	/**
+	 * Process the ready for capture event.
+	*
+	 * @param array $ledyer_payment_status The Ledyer payment status response.
+	 * @param \WC_Order $order The WooCommerce order object.
+	 * @param string $ledyer_order_id The Ledyer order ID.
+	 *
+	 * @return void
+	 */
+	private function process_ready_for_capture( $ledyer_payment_status, $order, $ledyer_order_id ) {
+	    $order->update_meta_data( '_ledyer_ready_for_capture', true );
+
+	    // If we where waiting for the ready for capture event, we can now complete the order.
+	    $waiting_on_ready_for_capture = $order->get_meta( '_ledyer_waiting_on_ready_for_capture', true );
+	    if ( ! empty( $waiting_on_ready_for_capture ) ) {
+	    	$order->delete_meta_data( '_ledyer_waiting_on_ready_for_capture' );
+	    	Logger::log( "[SCHEDULER]: Order {$order->get_order_number()} was waiting for ready_for_capture event. Now processing the order." );
+	    	$this->process_order_status( $ledyer_payment_status, $order, $ledyer_order_id );
+	    }
+
+	    // Save the order and return.
+	    $order->save();
+	}
+
+	/**
+	 * Process the order status based on the Ledyer payment status.
+	 *
+	 * @param array $ledyer_payment_status The Ledyer payment status response.
+	 * @param \WC_Order $order The WooCommerce order object.
+	 * @param string $ledyer_order_id The Ledyer order ID.
+	 *
+	 * @return void
+	 */
+	private function process_order_status( $ledyer_payment_status, $order, $ledyer_order_id ) {
 		$ack_order = false;
 
-		switch ( $ledyer_payment_status['status'] ) {
-			case \LedyerPaymentStatus::ORDER_PENDING:
-				if ( ! $order->has_status( array( 'on-hold', 'processing', 'completed' ) ) ) {
-					$note = sprintf(
-						__(
-							'New session created in Ledyer with Payment ID %1$s. %2$s',
-							'ledyer-checkout-for-woocommerce'
-						),
-						$ledyer_order_id,
-						$ledyer_payment_status['note']
-					);
-					$order->update_status( 'on-hold', $note );
-				}
-				break;
-			case \LedyerPaymentStatus::PAYMENT_PENDING:
-				if ( ! $order->has_status( array( 'on-hold', 'processing', 'completed' ) ) ) {
-					$note = sprintf(
-						__(
-							'New payment pending payment created in Ledyer with Payment ID %1$s. %2$s',
-							'ledyer-checkout-for-woocommerce'
-						),
-						$ledyer_order_id,
-						$ledyer_payment_status['note']
-					);
-					$order->update_status( 'on-hold', $note );
-					$ack_order = true;
-				}
-				break;
-			case \LedyerPaymentStatus::PAYMENT_CONFIRMED:
-				if ( ! $order->has_status( array( 'processing', 'completed' ) ) ) {
-					$note = sprintf(
-						__(
-							'Payment successfully confirmed in Ledyer with Payment ID %1$s. %2$s',
-							'ledyer-checkout-for-woocommerce'
-						),
-						$ledyer_order_id,
-						$ledyer_payment_status['note']
-					);
-					$order->add_order_note( $note );
-					$order->payment_complete( $ledyer_order_id );
-					$ack_order = true;
-				}
-				break;
-			case \LedyerPaymentStatus::ORDER_CAPTURED:
-				$new_status = 'completed';
+	    switch ( $ledyer_payment_status['status'] ) {
+	    	case \LedyerPaymentStatus::ORDER_PENDING:
+	    		if ( ! $order->has_status( array( 'on-hold', 'processing', 'completed' ) ) ) {
+	    			$note = sprintf(
+	    				__(
+	    					'New session created in Ledyer with Payment ID %1$s. %2$s',
+	    					'ledyer-checkout-for-woocommerce'
+	    				),
+	    				$ledyer_order_id,
+	    				$ledyer_payment_status['note']
+	    			);
+	    			$order->update_status( 'on-hold', $note );
+	    		}
+	    		break;
+	    	case \LedyerPaymentStatus::PAYMENT_PENDING:
+	    		if ( ! $order->has_status( array( 'on-hold', 'processing', 'completed' ) ) ) {
+	    			$note = sprintf(
+	    				__(
+	    					'New payment pending payment created in Ledyer with Payment ID %1$s. %2$s',
+	    					'ledyer-checkout-for-woocommerce'
+	    				),
+	    				$ledyer_order_id,
+	    				$ledyer_payment_status['note']
+	    			);
+	    			$order->update_status( 'on-hold', $note );
+	    			$ack_order = true;
+	    		}
+	    		break;
+	    	case \LedyerPaymentStatus::PAYMENT_CONFIRMED:
+	    		if ( ! $order->has_status( array( 'processing', 'completed' ) ) ) {
+	    			$note = sprintf(
+	    				__(
+	    					'Payment successfully confirmed in Ledyer with Payment ID %1$s. %2$s',
+	    					'ledyer-checkout-for-woocommerce'
+	    				),
+	    				$ledyer_order_id,
+	    				$ledyer_payment_status['note']
+	    			);
 
-				$settings = get_option( 'woocommerce_lco_settings' );
 
-				// Check if we should keep card payments in processing status.
-				if (
-					isset( $settings['keep_cards_processing'] )
-					&& 'yes' === $settings['keep_cards_processing']
-					&& isset( $ledyer_payment_status['paymentMethod'] )
-					&& isset( $ledyer_payment_status['paymentMethod']['type'] )
-					&& 'card' === $ledyer_payment_status['paymentMethod']['type']
-				) {
-					$new_status = 'processing';
+	    			$order->add_order_note( $note );
+
+	    			// If the order does not need payment, we need to ensure the "ready-for-capture" event has been triggered.
+	    			$ready_for_capture = $order->get_meta( '_ledyer_ready_for_capture', true );
+	    			if ( ! $order->needs_payment() && empty( $ready_for_capture ) ) {
+	    				// Set the metadata to indicate the order is still waiting for the ready for capture event.
+	    				$order->update_meta_data( '_ledyer_waiting_on_ready_for_capture', true );
+	    				$order->save();
+	    				Logger::log( "[SCHEDULER]: Order {$order->get_order_number()} is paid but waiting for ready_for_capture event." );
+	    				return;
+	    			}
+	    			$order->payment_complete( $ledyer_order_id );
+	    			$ack_order = true;
+	    		}
+	    		break;
+	    	case \LedyerPaymentStatus::ORDER_CAPTURED:
+	    		$new_status = 'completed';
+
+	    		$settings = get_option( 'woocommerce_lco_settings' );
+
+	    		// Check if we should keep card payments in processing status.
+	    		if (
+	    			isset( $settings['keep_cards_processing'] )
+	    			&& 'yes' === $settings['keep_cards_processing']
+	    			&& isset( $ledyer_payment_status['paymentMethod'] )
+	    			&& isset( $ledyer_payment_status['paymentMethod']['type'] )
+	    			&& 'card' === $ledyer_payment_status['paymentMethod']['type']
+	    		) {
+	    			$new_status = 'processing';
+	    		}
+
+	    		$new_status = apply_filters( 'lco_captured_update_status', $new_status, $ledyer_payment_status );
+	    		$order->update_status( $new_status );
+	    		break;
+	    	case \LedyerPaymentStatus::ORDER_REFUNDED:
+	    		$order->update_status( 'refunded' );
+	    		break;
+	    	case \LedyerPaymentStatus::ORDER_CANCELLED:
+	    		$order->update_status( 'cancelled' );
+	    		break;
+	    }
+
+		// If we need to acknowledge the order, do it now.
+	    if ( $ack_order ) {
+	    	$response = ledyer()->api->acknowledge_order( $ledyer_order_id );
+	    	if ( is_wp_error( $response ) ) {
+	    		Logger::log( "[SCHEDULER]: Couldn't acknowledge order $ledyer_order_id" );
+	    		return;
+	    	}
+
+			// If the merchant reference was not already set, set it now.
+			$merchant_reference = $order->get_meta( '_ledyer_merchant_reference', true );
+	    	if ( empty( $merchant_reference ) ) {
+				$ledyer_update_order = ledyer()->api->update_order_reference( $ledyer_order_id, array( 'reference' => $order->get_order_number() ) );
+				if ( is_wp_error( $ledyer_update_order ) ) {
+					Logger::log( "[SCHEDULER]: Couldn't set merchant reference {$order->get_order_number()}" );
+					return;
 				}
-
-				$new_status = apply_filters( 'lco_captured_update_status', $new_status, $ledyer_payment_status );
-				$order->update_status( $new_status );
-				break;
-			case \LedyerPaymentStatus::ORDER_REFUNDED:
-				$order->update_status( 'refunded' );
-				break;
-			case \LedyerPaymentStatus::ORDER_CANCELLED:
-				$order->update_status( 'cancelled' );
-				break;
-		}
-
-		if ( $ack_order ) {
-			$response = ledyer()->api->acknowledge_order( $ledyer_order_id );
-			if ( is_wp_error( $response ) ) {
-				Logger::log( "[SCHEDULER]: Couldn't acknowledge order $ledyer_order_id" );
-				return;
 			}
-			$ledyer_update_order = ledyer()->api->update_order_reference( $ledyer_order_id, array( 'reference' => $order->get_order_number() ) );
-			if ( is_wp_error( $ledyer_update_order ) ) {
-				Logger::log( "[SCHEDULER]: Couldn't set merchant reference {$order->get_order_number()}" );
-				return;
-			}
-		}
+	    }
 	}
 }

--- a/classes/class-ledyer-callback.php
+++ b/classes/class-ledyer-callback.php
@@ -206,7 +206,7 @@ class Callback {
 				if ( ! $order->has_status( array( 'on-hold', 'processing', 'completed' ) ) ) {
 					$note = sprintf(
 						__(
-							'New payment created in Ledyer with Payment ID %1$s. %2$s',
+							'New payment pending payment created in Ledyer with Payment ID %1$s. %2$s',
 							'ledyer-checkout-for-woocommerce'
 						),
 						$ledyer_order_id,
@@ -220,7 +220,7 @@ class Callback {
 				if ( ! $order->has_status( array( 'processing', 'completed' ) ) ) {
 					$note = sprintf(
 						__(
-							'New payment created in Ledyer with Payment ID %1$s. %2$s',
+							'Payment successfully confirmed in Ledyer with Payment ID %1$s. %2$s',
 							'ledyer-checkout-for-woocommerce'
 						),
 						$ledyer_order_id,

--- a/classes/class-ledyer-confirmation.php
+++ b/classes/class-ledyer-confirmation.php
@@ -84,6 +84,8 @@ class Confirmation {
 		$ledyer_update_order_reference = ledyer()->api->update_order_reference( $payment_id, array( 'reference' => $order->get_order_number() ) );
 		if ( is_wp_error( $ledyer_update_order_reference ) ) {
 			\Ledyer\Logger::log( "Couldn't set merchant reference {$order->get_order_number()}" );
+		} else {
+			$order->update_meta_data( '_ledyer_merchant_reference', $order->get_order_number() );
 		}
 
 		$ledyer_note           = '';

--- a/classes/class-ledyer-confirmation.php
+++ b/classes/class-ledyer-confirmation.php
@@ -131,10 +131,10 @@ class Confirmation {
 		if ( 'advanceInvoice' === $ledyer_payment_type ) {
 			$order->update_status( 'on-hold', $note );
 		} elseif ( $order->needs_processing() ) {
-			$order->update_status( 'on-hold', $note );
-		} else {
 			$order->add_order_note( $note );
 			$order->payment_complete( $payment_id );
+		} else {
+			$order->update_status( 'on-hold', $note );
 		}
 
 		$order->update_meta_data( '_ledyer_date_paid', gmdate( 'Y-m-d H:i:s' ) );

--- a/classes/class-ledyer-confirmation.php
+++ b/classes/class-ledyer-confirmation.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Confirmation Class file.
+ *
+ * @package Ledyer
+ */
+
+namespace Ledyer;
+
+\defined( 'ABSPATH' ) || die();
+
+/**
+ * Confirmation class.
+ *
+ * @since 1.0.0
+ *
+ * Class that handles confirmation of order and redirect to Thank you page.
+ */
+class Confirmation {
+
+	use Singleton;
+
+	/**
+	 * Confirmation constructor.
+	 */
+	public function actions() {
+		add_action( 'init', array( $this, 'handle_redirect' ), 10, 2 );
+	}
+
+	/**
+	 * Confirm the order in Woo
+	 */
+	public function handle_redirect() {
+		$ledyer_confirm = filter_input( INPUT_GET, 'lco_confirm', FILTER_SANITIZE_URL );
+		$order_key      = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+
+		if ( empty( $ledyer_confirm ) || empty( $order_key ) ) {
+			return;
+		}
+		$order_id = wc_get_order_id_by_order_key( $order_key );
+
+		if ( empty( $order_id ) ) {
+			\Ledyer\Logger::log( "Could not get the WooCommerce order id from order key {$order_key}" );
+			return;
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( empty( $order ) ) {
+			\Ledyer\Logger::log( "Could not get the WooCommerce order with the id {$order_id}" );
+			return;
+		}
+
+		Logger::log( "{$order_id}: Confirm the Ledyer order from the confirmation page." );
+		$this->confirm_order( $order );
+		lco_unset_sessions();
+	}
+
+	/**
+	 * Confirm the order in WooCommerce.
+	 *
+	 * @param \WC_Order $order WooCommerce order.
+	 *
+	 * @return void
+	 */
+	private function confirm_order( $order ) {
+		// Advanced invoice must be set to on-hold regardless of needs_processing().
+		// For all other payment methods, if the order needs processing, set to on-hold, and handle it through callback.
+		// Otherwise, process the order through payment_complete().
+
+		// If the order is already completed or on-hold, return.
+		if ( ! empty( $order->get_date_paid() ) || $order->has_status( array( 'on-hold' ) ) ) {
+			return;
+		}
+
+		$payment_id = $order->get_meta( '_wc_ledyer_order_id' );
+		if ( empty( $payment_id ) ) {
+			\Ledyer\Logger::log( "Could not get the Ledyer payment id from the order {$order->get_id()}" );
+			return;
+		}
+
+		$ledyer_order = ledyer()->api->get_order( $payment_id );
+		$order->set_transaction_id( $payment_id );
+
+		$ledyer_update_order_reference = ledyer()->api->update_order_reference( $payment_id, array( 'reference' => $order->get_order_number() ) );
+		if ( is_wp_error( $ledyer_update_order_reference ) ) {
+			\Ledyer\Logger::log( "Couldn't set merchant reference {$order->get_order_number()}" );
+		}
+
+		$ledyer_note           = '';
+		$ledyer_payment_method = $ledyer_order['paymentMethod'];
+		$ledyer_payment_status = ledyer()->api->get_payment_status( $payment_id );
+		if ( ! is_wp_error( $ledyer_payment_status ) ) {
+			$ledyer_payment_method = $ledyer_payment_status['paymentMethod'];
+			$ledyer_note           = sanitize_text_field( $ledyer_payment_status['note'] ) ?? '';
+		}
+		$ledyer_payment_provider = sanitize_text_field( $ledyer_payment_method['provider'] );
+		$ledyer_payment_type     = sanitize_text_field( $ledyer_payment_method['type'] );
+
+		$order->update_meta_data( 'ledyer_payment_type', $ledyer_payment_type );
+		$order->update_meta_data( 'ledyer_payment_method', $ledyer_payment_provider );
+
+		switch ( $ledyer_payment_type ) {
+			case 'invoice':
+				$method_title = __( 'Invoice', 'ledyer-checkout-for-woocommerce' );
+				break;
+			case 'advanceInvoice':
+				$method_title = __( 'Advance Invoice', 'ledyer-checkout-for-woocommerce' );
+				break;
+			case 'card':
+				$method_title = __( 'Card', 'ledyer-checkout-for-woocommerce' );
+				break;
+			case 'bankTransfer':
+				$method_title = __( 'Direct Debit', 'ledyer-checkout-for-woocommerce' );
+				break;
+			case 'partPayment':
+				$method_title = __( 'Part Payment', 'ledyer-checkout-for-woocommerce' );
+				break;
+		}
+
+		$order->set_payment_method_title( sprintf( '%s (Ledyer)', $method_title ) );
+
+		$note = sprintf(
+			// translators: 1: Payment ID, 2: Note from Ledyer.
+			__(
+				'New payment created in Ledyer with Payment ID %1$s. %2$s',
+				'ledyer-checkout-for-woocommerce'
+			),
+			$payment_id,
+			$ledyer_note
+		);
+		if ( 'advanceInvoice' === $ledyer_payment_type ) {
+			$order->update_status( 'on-hold', $note );
+		} elseif ( $order->needs_processing() ) {
+			$order->update_status( 'on-hold', $note );
+		} else {
+			$order->add_order_note( $note );
+			$order->payment_complete( $payment_id );
+		}
+
+		$order->update_meta_data( '_ledyer_date_paid', gmdate( 'Y-m-d H:i:s' ) );
+		$order->save();
+
+		do_action( 'ledyer_process_payment', $order->get_id(), $ledyer_order );
+
+		$response = ledyer()->api->acknowledge_order( $payment_id );
+		if ( is_wp_error( $response ) ) {
+			\Ledyer\Logger::log( "Couldn't acknowledge order {$payment_id}|{$order->get_id()}" );
+		}
+	}
+}

--- a/classes/class-ledyer-logger.php
+++ b/classes/class-ledyer-logger.php
@@ -71,9 +71,16 @@ class Logger {
 		if ( isset( $response['snippet'] ) ) {
 			unset( $response['snippet'] );
 		}
-		// Unset the snippet to prevent issues in the request body.
-		if ( isset( $request_args['body'] ) ) {
-			$request_body = json_decode( $request_args['body'], true );
+
+		// Mask the access token in the response.
+		if ( isset( $response['access_token'] ) ) {
+			$response['access_token'] = '[REDACTED]';
+		}
+
+		// Mask the authorization header.
+		if ( isset( $request_args['headers']['Authorization'] ) ) {
+			$replacement = strlen( $request_args['headers']['Authorization'] ) > 15 ? '[REDACTED]' : '[MISSING]';
+			$request_args['headers']['Authorization'] = $replacement;
 		}
 
 		return array(
@@ -82,7 +89,7 @@ class Logger {
 			'title'          => $title,
 			'request'        => $request_args,
 			'response'       => array(
-				'body' => $request_body ?? $response,
+				'body' => $response,
 				'code' => $code,
 			),
 			'timestamp'      => gmdate( 'Y-m-d H:i:s' ),

--- a/classes/class-ledyer-main.php
+++ b/classes/class-ledyer-main.php
@@ -91,6 +91,7 @@ class Ledyer_Checkout_For_WooCommerce {
 
 		AJAX::init();
 		Templates::instance();
+		Confirmation::instance();
 		Checkout::instance();
 		Callback::instance();
 
@@ -134,6 +135,7 @@ class Ledyer_Checkout_For_WooCommerce {
 		include_once LCO_WC_PLUGIN_PATH . '/classes/class-ledyer-ajax.php';
 		include_once LCO_WC_PLUGIN_PATH . '/classes/class-ledyer-api.php';
 		include_once LCO_WC_PLUGIN_PATH . '/classes/class-ledyer-checkout.php';
+		include_once LCO_WC_PLUGIN_PATH . '/classes/class-ledyer-confirmation.php';
 		include_once LCO_WC_PLUGIN_PATH . '/classes/class-ledyer-credentials.php';
 		include_once LCO_WC_PLUGIN_PATH . '/classes/class-ledyer-fields.php';
 		include_once LCO_WC_PLUGIN_PATH . '/classes/class-ledyer-lco-gateway.php';

--- a/classes/requests/class-ledyer-request.php
+++ b/classes/requests/class-ledyer-request.php
@@ -55,6 +55,13 @@ abstract class Request {
 	 */
 	protected $request_url;
 	/**
+	 * The log title to use for the debug log.
+	 *
+	 * @var string
+	 */
+	protected $log_title = '';
+
+	/**
 	 * Requests Class constructor.
 	 *
 	 * @param array $arguments Request arguments.
@@ -209,7 +216,7 @@ abstract class Request {
 	protected function process_response( $response, $request_args, $request_url ) {
 		$code = wp_remote_retrieve_response_code( $response );
 
-		$log = Logger::format_log( '', 'POST', 'Debugger', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
+		$log = Logger::format_log( '', 'POST', $this->log_title, $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
 
 		Logger::log( $log );
 

--- a/classes/requests/class-ledyer-request.php
+++ b/classes/requests/class-ledyer-request.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * Abstract Request
  *
@@ -6,7 +6,6 @@
  */
 namespace Ledyer\Requests;
 
-use Ledyer\Credentials;
 use Ledyer\Logger;
 
 defined( 'ABSPATH' ) || exit();
@@ -114,7 +113,7 @@ abstract class Request {
 		$client = new \WP_Http();
 
 		$headers = array(
-			'Authorization' => 'Basic ' . base64_encode( $client_credentials['merchant_id'] . ':' . $client_credentials['shared_secret'] ),
+			'Authorization' => 'Basic ' . base64_encode( $client_credentials['merchant_id'] . ':' . $client_credentials['shared_secret'] ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
 		);
 
 		$response = $client->post(
@@ -176,7 +175,7 @@ abstract class Request {
 		);
 
 		if ( 'POST' === $this->method && $this->arguments['data'] ) {
-			$request_args['body'] = json_encode( $this->arguments['data'] );
+			$request_args['body'] = wp_json_encode( $this->arguments['data'] );
 		}
 
 		return $request_args;

--- a/classes/requests/helpers/class-ledyer-woocommerce-bridge.php
+++ b/classes/requests/helpers/class-ledyer-woocommerce-bridge.php
@@ -187,6 +187,7 @@ class Woocommerce_Bridge {
 					'showShippingAddressContact' => 'yes' === ledyer()->get_setting( 'show_shipping_address_contact' ),
 				),
 				'urls'     => array(
+					'notification' => apply_filters( 'lco_notification_url', home_url( Callback::API_ENDPOINT ) ),
 					'terms'        => $merchant_urls['terms'],
 					'privacy'      => $merchant_urls['privacy'],
 					'confirmation' => '',
@@ -194,12 +195,6 @@ class Woocommerce_Bridge {
 				),
 			);
 		}
-
-		// This should always be set, even if not full.
-		self::$ledyer_settings['urls']['notification'] = apply_filters(
-			'lco_notification_url',
-			home_url( Callback::API_ENDPOINT )
-		);
 	}
 
 	/**

--- a/classes/requests/order/management/class-ledyer-acknowledge-order.php
+++ b/classes/requests/order/management/class-ledyer-acknowledge-order.php
@@ -16,12 +16,20 @@ defined( 'ABSPATH' ) || exit();
  * @package Ledyer\Requests\Order\Management
  */
 class Acknowledge_Order extends Request_Order {
-		/**
-		 * Request method
-		 *
-		 * @var string
-		 */
+	/**
+	 * Request method
+	 *
+	 * @var string
+	 */
 	protected $method = 'POST';
+
+	/**
+	 * The log title to use for the debug log.
+	 *
+	 * @var string
+	 */
+	protected $log_title = 'Acknowledge order';
+
 	/**
 	 * Set entrypoint
 	 */

--- a/classes/requests/order/management/class-ledyer-get-order.php
+++ b/classes/requests/order/management/class-ledyer-get-order.php
@@ -23,9 +23,17 @@ class Get_Order extends Request_Order {
 	 */
 
 	protected $method = 'GET';
-		/**
-		 * Set entrypoint
-		 */
+
+	/**
+	 * The log title to use for the debug log.
+	 *
+	 * @var string
+	 */
+	protected $log_title = 'Get order';
+
+	/**
+	 * Set entrypoint
+	 */
 	protected function set_url() {
 		$this->url = sprintf( 'v1/orders/%s', $this->arguments['orderId'] );
 

--- a/classes/requests/order/management/class-ledyer-get-payment-status.php
+++ b/classes/requests/order/management/class-ledyer-get-payment-status.php
@@ -23,6 +23,14 @@ class Get_Payment_Status extends Request_Order {
 	 */
 
 	protected $method = 'GET';
+
+	/**
+	 * The log title to use for the debug log.
+	 *
+	 * @var string
+	 */
+	protected $log_title = 'Get payment status';
+
 	/**
 	 * Set entrypoint
 	 */

--- a/classes/requests/order/management/class-ledyer-update-order-reference.php
+++ b/classes/requests/order/management/class-ledyer-update-order-reference.php
@@ -24,6 +24,13 @@ class Update_Order_Reference extends Request_Order {
 	protected $method = 'POST';
 
 	/**
+	 * The log title to use for the debug log.
+	 *
+	 * @var string
+	 */
+	protected $log_title = 'Update merchant reference';
+
+	/**
 	 * Set entrypoint
 	 */
 	protected function set_url() {

--- a/classes/requests/order/session/class-ledyer-create-order.php
+++ b/classes/requests/order/session/class-ledyer-create-order.php
@@ -21,6 +21,14 @@ class Create_Order extends Request_Order {
 	 */
 
 	protected $method = 'POST';
+
+	/**
+	 * The log title to use for the debug log.
+	 *
+	 * @var string
+	 */
+	protected $log_title = 'Create session';
+
 	/**
 	 * Set entrypoint
 	 */

--- a/classes/requests/order/session/class-ledyer-get-order.php
+++ b/classes/requests/order/session/class-ledyer-get-order.php
@@ -22,6 +22,14 @@ class Get_Order extends Request_Order {
 	 * @var string
 	 */
 	protected $method = 'GET';
+
+	/**
+	 * The log title to use for the debug log.
+	 *
+	 * @var string
+	 */
+	protected $log_title = 'Get session';
+
 	/**
 	 * Set entrypoint
 	 */

--- a/classes/requests/order/session/class-ledyer-update-order.php
+++ b/classes/requests/order/session/class-ledyer-update-order.php
@@ -20,6 +20,14 @@ class Update_Order extends Request_Order {
 	 * Set entrypoint
 	 */
 	protected $method = 'POST';
+
+	/**
+	 * The log title to use for the debug log.
+	 *
+	 * @var string
+	 */
+	protected $log_title = 'Update session';
+
 	/*
 	 * Request method
 	 */

--- a/includes/lco-functions.php
+++ b/includes/lco-functions.php
@@ -60,22 +60,20 @@ function lco_create_or_update_order() {
 			);
 
 			return $ledyer_order;
-		} else {
+		} elseif ( ( $ledyer_order_id !== $ledyer_order['orderId'] ) || ( $ledyer_session_id !== $ledyer_order['sessionId'] ) ) {
 			// If sessions somehow change??
-			if ( ( $ledyer_order_id !== $ledyer_order['orderId'] ) || ( $ledyer_session_id !== $ledyer_order['sessionId'] ) ) {
-				WC()->session->set( 'lco_wc_session_id', $ledyer_order['sessionId'] );
-				WC()->session->set( 'lco_wc_order_id', $ledyer_order['orderId'] );
-				WC()->session->set(
-					'lco_wc_settings',
-					array(
-						'allow_custom_shipping'         => ledyer()->get_setting( 'allow_custom_shipping' ),
-						'show_shipping_address_contact' => ledyer()->get_setting( 'show_shipping_address_contact' ),
-						'customer_show_name_fields'     => ledyer()->get_setting( 'customer_show_name_fields' ),
-						'terms_url'                     => ledyer()->get_setting( 'terms_url' ),
-						'privacy_url'                   => ledyer()->get_setting( 'privacy_url' ),
-					)
-				);
-			}
+			WC()->session->set( 'lco_wc_session_id', $ledyer_order['sessionId'] );
+			WC()->session->set( 'lco_wc_order_id', $ledyer_order['orderId'] );
+			WC()->session->set(
+				'lco_wc_settings',
+				array(
+					'allow_custom_shipping'         => ledyer()->get_setting( 'allow_custom_shipping' ),
+					'show_shipping_address_contact' => ledyer()->get_setting( 'show_shipping_address_contact' ),
+					'customer_show_name_fields'     => ledyer()->get_setting( 'customer_show_name_fields' ),
+					'terms_url'                     => ledyer()->get_setting( 'terms_url' ),
+					'privacy_url'                   => ledyer()->get_setting( 'privacy_url' ),
+				)
+			);
 		}
 		return $ledyer_order;
 	} else {
@@ -194,8 +192,7 @@ function wc_ledyer_cart_redirect() {
 	$url = add_query_arg(
 		array(
 			'lco-order' => 'error',
-			'reason'    => base64_encode( __( 'Failed to load Ledyer Checkout template file.', 'ledyer-checkout-for-woocommerce' ) ),
-			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
+			'reason'    => base64_encode( __( 'Failed to load Ledyer Checkout template file.', 'ledyer-checkout-for-woocommerce' ) ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
 		),
 		wc_get_cart_url()
 	);

--- a/includes/lco-types.php
+++ b/includes/lco-types.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
 \defined( 'ABSPATH' ) || die();
 

--- a/templates/ledyer-checkout.php
+++ b/templates/ledyer-checkout.php
@@ -11,7 +11,7 @@ do_action( 'woocommerce_before_checkout_form', WC()->checkout() );
 
 // If checkout registration is disabled and not logged in, the user cannot checkout.
 if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_required() && ! is_user_logged_in() ) {
-	echo esc_html( apply_filters( 'woocommerce_checkout_must_be_logged_in_message', __( 'You must be logged in to checkout.', 'woocommerce' ) ) );
+	echo esc_html( apply_filters( 'woocommerce_checkout_must_be_logged_in_message', __( 'You must be logged in to checkout.', 'woocommerce' ) ) ); // phpcs:ignore
 	return;
 }
 
@@ -40,7 +40,7 @@ $vertical_layout = 'yes' === ledyer()->get_setting( 'vertical_layout' ) ? 'verti
 			<?php
 			do_action( 'lco_wc_before_snippet' );
 
-			// Create or update the order and handle redirection
+			// Create or update the order and handle redirection.
 			$ledyer_order = lco_create_or_update_order();
 			if ( false === $ledyer_order ) :
 				wc_ledyer_cart_redirect();


### PR DESCRIPTION
```
Advanced invoice must be set to on-hold regardless of needs_processing().
For all other payment methods, if the order needs processing, set to on-hold, and handle it through callback.
Otherwise, process the order through payment_complete().
```

https://app.clickup.com/t/86983qdfz